### PR TITLE
add more features encoding

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,7 @@
 init:
 	git submodule update --init
 
-compile:
-	cython -3 --cplus vtzero/tile.pyx
+compile: 
 	python setup.py build_ext --inplace
 
 test:

--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ Experimental Python wrapper of [vtzero](https://github.com/mapbox/vtzero) a mini
 $ git clone https://github.com/tilery/python-vtzero
 $ cd python-vtzero
 
-# download vendor submodules (protozero, mvt-fixtures, vtzero)
-$ make init
+# Download vendor submodules (protozero, mvt-fixtures, vtzero)
+$ git submodule update --init
 
-# Compile .pyx and build
-$ make compile
+# Compile Cython module
+$ python setup.py build_ext --inplace
 ```
 
 ## Install

--- a/README.md
+++ b/README.md
@@ -1,18 +1,47 @@
 # python-vtzero
 
-Experimental wrapper of [vtzero](https://github.com/mapbox/vtzero)
+Experimental Python wrapper of [vtzero](https://github.com/mapbox/vtzero) a minimalist vector tile decoder and encoder in C++
 
+## Build 
 
-## Development
+```bash
+$ git clone https://github.com/tilery/python-vtzero
+$ cd python-vtzero
 
-Clone this repository, then
+# download vendor submodules (protozero, mvt-fixtures, vtzero)
+$ make init
 
-    make init
+# Compile .pyx and build
+$ make compile
+```
 
-To compile:
+## Install
 
-    make compile
+```bash
+$ pip install -e .
+```
 
-To run tests:
+## Example
 
-    make test
+A complete example can be found [here](example/__init__.py)
+
+```python
+from vtzero.tile import VectorTile, Tile, Layer, Point
+
+# Create MVT
+tile = Tile()
+
+# Add a layer
+layer = Layer(tile, b'my_layer')
+
+# Add a point
+feature = Point(layer)
+feature.add_points(1)
+feature.set_point(10, 10)
+feature.add_property(b'foo', b'bar')
+feature.add_property(b'x', b'y')
+feature.commit()
+
+# Encode mvt
+data = tile.serialize()
+```

--- a/example/__init__.py
+++ b/example/__init__.py
@@ -1,12 +1,24 @@
-from vtzero.tile import Tile, Layer, Point
+from vtzero.tile import Tile, Layer, Point, Polygon
 
 tile = Tile()
 points = Layer(tile, b'points')
-feature = Point(points, 1)
+feature = Point(points)
 feature.add_points(1)
 feature.set_point(10, 10)
 feature.add_property(b'foo', b'bar')
 feature.add_property(b'x', b'y')
 feature.commit()
 data = tile.serialize()
-print(data)
+
+
+tile = Tile()
+mvt_layer = Layer(tile, b'polygons')
+feature = Polygon(mvt_layer)
+feature.add_ring(5)
+feature.set_point(0, 0)
+feature.set_point(1, 0)
+feature.set_point(1, 1)
+feature.set_point(0, 1)
+feature.close_ring()
+feature.commit()
+data = tile.serialize()

--- a/example/__init__.py
+++ b/example/__init__.py
@@ -1,19 +1,21 @@
-from vtzero.tile import Tile, Layer, Point, Polygon
+from vtzero.tile import VectorTile, Tile, Layer, Point, Polygon, Linestring
 
+# Create MVT
 tile = Tile()
-points = Layer(tile, b'points')
-feature = Point(points)
+
+# Add a layer
+layer = Layer(tile, b'my_layer')
+
+# Add a point
+feature = Point(layer)
 feature.add_points(1)
 feature.set_point(10, 10)
 feature.add_property(b'foo', b'bar')
 feature.add_property(b'x', b'y')
 feature.commit()
-data = tile.serialize()
 
-
-tile = Tile()
-mvt_layer = Layer(tile, b'polygons')
-feature = Polygon(mvt_layer)
+# Add a polygon
+feature = Polygon(layer)
 feature.add_ring(5)
 feature.set_point(0, 0)
 feature.set_point(1, 0)
@@ -21,4 +23,28 @@ feature.set_point(1, 1)
 feature.set_point(0, 1)
 feature.close_ring()
 feature.commit()
+
+# Add a line
+feature = Linestring(layer)
+feature.add_linestring(3)
+feature.set_point(0, 0)
+feature.set_point(1, 1)
+feature.set_point(2, 2)
+feature.commit()
+
+# Encode mvt
 data = tile.serialize()
+
+# Decode MVT and print info
+tile = VectorTile(data)
+layer = next(tile)
+print(f"Layer Name: {layer.name.decode()}")
+print(f"MVT version: {layer.version}")
+print(f"MVT extent: {layer.extent}")
+features = []
+while True:
+    f = next(layer)
+    if f.geometry_type == 0:
+        break
+    features.append(f)
+print(f"Nb Features: {len(features)}")

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+"""python-vtzero setup."""
+
 import os
 
 from setuptools import setup
@@ -11,7 +13,7 @@ ext_options = {
     'extra_compile_args': ['-O2', '-std=c++14']
 }
 ext_modules = cythonize([
-    Extension('vtzero.tile', ['vtzero/tile.cpp'], **ext_options)
+    Extension('vtzero.tile', ['vtzero/tile.pyx'], language="c++", **ext_options)
 ])
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,18 @@
 import os
-from setuptools import setup, Extension
+
+from setuptools import setup
+from setuptools.extension import Extension
+from Cython.Build import cythonize
 
 os.environ["CC"] = 'clang++'
 
+ext_options = {
+    'include_dirs': ['./vendor/vtzero/include', './vendor/protozero/include'],
+    'extra_compile_args': ['-O2', '-std=c++14']
+}
+ext_modules = cythonize([
+    Extension('vtzero.tile', ['vtzero/tile.cpp'], **ext_options)
+])
 
 setup(
     name='vtzero',
@@ -23,15 +33,7 @@ setup(
     author_email='yohan.boniface@data.gouv.fr',
     license='MIT',
     packages=['vtzero'],
-    ext_modules=[
-        Extension(
-            'vtzero.tile',
-            ['vtzero/tile.cpp'],
-            extra_compile_args=['-O2', '-std=c++14'],
-            include_dirs=['./vendor/vtzero/include',
-                          './vendor/protozero/include'],
-        )
-    ],
+    ext_modules=ext_modules,
     provides=['vtzero'],
     include_package_data=True
 )

--- a/tests/test_tile.py
+++ b/tests/test_tile.py
@@ -1,4 +1,4 @@
-from vtzero.tile import Tile, Layer, Point, Polygon
+from vtzero.tile import Tile, Layer, Point, Polygon, Linestring
 
 
 def test_point_encoding():
@@ -46,6 +46,20 @@ def test_polygon_encoding_close_ring():
     assert tile.serialize() == b'\x1a/x\x02\n\x07polygon(\x80 \x12\x13\x18\x03"\x0b\t\x00\x00\x1a\x14\x00\x00\x14\x13\x00\x0f\x12\x02\x00\x00\x1a\x03foo"\x05\n\x03bar'  # noqa
 
 
+def test_linestring_encoding():
+    """Test creation of linestring feature."""
+    tile = Tile()
+    line = Layer(tile, b'linestring')
+    feature = Linestring(line)
+    feature.add_linestring(3)
+    feature.set_point(0, 0)
+    feature.set_point(10, 10)
+    feature.set_point(20, 20)
+    feature.add_property(b'foo', b'bar')
+    feature.commit()
+    assert tile.serialize() == b'\x1a/x\x02\n\nlinestring(\x80 \x12\x10\x18\x02"\x08\t\x00\x00\x12\x14\x14\x14\x14\x12\x02\x00\x00\x1a\x03foo"\x05\n\x03bar'  # noqa
+
+
 def test_set_id_valid():
     """Test set_id method."""
     tile = Tile()
@@ -59,7 +73,6 @@ def test_set_id_valid():
     feature.commit()
     assert tile.serialize() == b'\x1a2x\x02\n\x06points(\x80 \x12\x0f\x18\x01\x08\x01"\x03\t\x14\x14\x12\x04\x00\x00\x01\x01\x1a\x03foo\x1a\x01x"\x05\n\x03bar"\x03\n\x01y'  # noqa
 
-
     tile = Tile()
     poly = Layer(tile, b'polygon')
     feature = Polygon(poly)
@@ -72,3 +85,14 @@ def test_set_id_valid():
     feature.set_point(0, 0)
     feature.commit()
     assert tile.serialize() == b'\x1a!x\x02\n\x07polygon(\x80 \x12\x11\x18\x03\x08\x01"\x0b\t\x00\x00\x1a\x14\x00\x00\x14\x13\x00\x0f'  # noqa
+
+    tile = Tile()
+    line = Layer(tile, b'linestring')
+    feature = Linestring(line)
+    feature.set_id(1)
+    feature.add_linestring(3)
+    feature.set_point(0, 0)
+    feature.set_point(10, 10)
+    feature.set_point(20, 20)
+    feature.commit()
+    assert tile.serialize() == b'\x1a!x\x02\n\nlinestring(\x80 \x12\x0e\x18\x02\x08\x01"\x08\t\x00\x00\x12\x14\x14\x14\x14'  # noqa

--- a/tests/test_tile.py
+++ b/tests/test_tile.py
@@ -2,6 +2,7 @@ from vtzero.tile import Tile, Layer, Point, Polygon
 
 
 def test_point_encoding():
+    """Test creation of point feature."""
     tile = Tile()
     points = Layer(tile, b'points')
     feature = Point(points)
@@ -12,6 +13,41 @@ def test_point_encoding():
     feature.commit()
     assert tile.serialize() == b'\x1a0x\x02\n\x06points(\x80 \x12\r\x18\x01"\x03\t\x14\x14\x12\x04\x00\x00\x01\x01\x1a\x03foo\x1a\x01x"\x05\n\x03bar"\x03\n\x01y'  # noqa
 
+
+def test_polygon_encoding():
+    """Test creation of polygon feature."""
+    tile = Tile()
+    poly = Layer(tile, b'polygon')
+    feature = Polygon(poly)
+    feature.add_ring(5)
+    feature.set_point(0, 0)
+    feature.set_point(10, 0)
+    feature.set_point(10, 10)
+    feature.set_point(0, 10)
+    feature.set_point(0, 0)
+    feature.add_property(b'foo', b'bar')
+    feature.commit()
+    assert tile.serialize() == b'\x1a/x\x02\n\x07polygon(\x80 \x12\x13\x18\x03"\x0b\t\x00\x00\x1a\x14\x00\x00\x14\x13\x00\x0f\x12\x02\x00\x00\x1a\x03foo"\x05\n\x03bar'  # noqa
+
+
+def test_polygon_encoding_close_ring():
+    """Test creation of polygon feature with 'close_ring' method."""
+    tile = Tile()
+    poly = Layer(tile, b'polygon')
+    feature = Polygon(poly)
+    feature.add_ring(5)
+    feature.set_point(0, 0)
+    feature.set_point(10, 0)
+    feature.set_point(10, 10)
+    feature.set_point(0, 10)
+    feature.close_ring()
+    feature.add_property(b'foo', b'bar')
+    feature.commit()
+    assert tile.serialize() == b'\x1a/x\x02\n\x07polygon(\x80 \x12\x13\x18\x03"\x0b\t\x00\x00\x1a\x14\x00\x00\x14\x13\x00\x0f\x12\x02\x00\x00\x1a\x03foo"\x05\n\x03bar'  # noqa
+
+
+def test_set_id_valid():
+    """Test set_id method."""
     tile = Tile()
     points = Layer(tile, b'points')
     feature = Point(points)
@@ -24,21 +60,6 @@ def test_point_encoding():
     assert tile.serialize() == b'\x1a2x\x02\n\x06points(\x80 \x12\x0f\x18\x01\x08\x01"\x03\t\x14\x14\x12\x04\x00\x00\x01\x01\x1a\x03foo\x1a\x01x"\x05\n\x03bar"\x03\n\x01y'  # noqa
 
 
-def test_polygon_encoding():
-    tile = Tile()
-    poly = Layer(tile, b'polygon')
-    feature = Polygon(poly)
-    feature.add_ring(5)
-    feature.set_point(0, 0)
-    feature.set_point(10, 0)
-    feature.set_point(10, 10)
-    feature.set_point(0, 10)
-    feature.close_ring()
-    feature.add_property(b'foo', b'bar')
-    feature.add_property(b'x', b'y')
-    feature.commit()
-    assert tile.serialize() == b'\x1a9x\x02\n\x07polygon(\x80 \x12\x15\x18\x03"\x0b\t\x00\x00\x1a\x14\x00\x00\x14\x13\x00\x0f\x12\x04\x00\x00\x01\x01\x1a\x03foo\x1a\x01x"\x05\n\x03bar"\x03\n\x01y'  # noqa
-
     tile = Tile()
     poly = Layer(tile, b'polygon')
     feature = Polygon(poly)
@@ -48,22 +69,6 @@ def test_polygon_encoding():
     feature.set_point(10, 0)
     feature.set_point(10, 10)
     feature.set_point(0, 10)
-    feature.close_ring()
-    feature.add_property(b'foo', b'bar')
-    feature.add_property(b'x', b'y')
-    feature.commit()
-    assert tile.serialize() == b'\x1a;x\x02\n\x07polygon(\x80 \x12\x17\x18\x03\x08\x01"\x0b\t\x00\x00\x1a\x14\x00\x00\x14\x13\x00\x0f\x12\x04\x00\x00\x01\x01\x1a\x03foo\x1a\x01x"\x05\n\x03bar"\x03\n\x01y'  # noqa
-
-    tile = Tile()
-    poly = Layer(tile, b'polygon')
-    feature = Polygon(poly)
-    feature.add_ring(5)
     feature.set_point(0, 0)
-    feature.set_point(10, 0)
-    feature.set_point(10, 10)
-    feature.set_point(0, 10)
-    feature.set_point(0, 0)
-    feature.add_property(b'foo', b'bar')
-    feature.add_property(b'x', b'y')
     feature.commit()
-    assert tile.serialize() == b'\x1a9x\x02\n\x07polygon(\x80 \x12\x15\x18\x03"\x0b\t\x00\x00\x1a\x14\x00\x00\x14\x13\x00\x0f\x12\x04\x00\x00\x01\x01\x1a\x03foo\x1a\x01x"\x05\n\x03bar"\x03\n\x01y'  # noqa
+    assert tile.serialize() == b'\x1a!x\x02\n\x07polygon(\x80 \x12\x11\x18\x03\x08\x01"\x0b\t\x00\x00\x1a\x14\x00\x00\x14\x13\x00\x0f'  # noqa

--- a/tests/test_tile.py
+++ b/tests/test_tile.py
@@ -1,13 +1,69 @@
-from vtzero.tile import Tile, Layer, Point
+from vtzero.tile import Tile, Layer, Point, Polygon
 
 
 def test_point_encoding():
     tile = Tile()
     points = Layer(tile, b'points')
-    feature = Point(points, 1)
+    feature = Point(points)
     feature.add_points(1)
     feature.set_point(10, 10)
     feature.add_property(b'foo', b'bar')
     feature.add_property(b'x', b'y')
     feature.commit()
     assert tile.serialize() == b'\x1a0x\x02\n\x06points(\x80 \x12\r\x18\x01"\x03\t\x14\x14\x12\x04\x00\x00\x01\x01\x1a\x03foo\x1a\x01x"\x05\n\x03bar"\x03\n\x01y'  # noqa
+
+    tile = Tile()
+    points = Layer(tile, b'points')
+    feature = Point(points)
+    feature.set_id(1)
+    feature.add_points(1)
+    feature.set_point(10, 10)
+    feature.add_property(b'foo', b'bar')
+    feature.add_property(b'x', b'y')
+    feature.commit()
+    assert tile.serialize() == b'\x1a2x\x02\n\x06points(\x80 \x12\x0f\x18\x01\x08\x01"\x03\t\x14\x14\x12\x04\x00\x00\x01\x01\x1a\x03foo\x1a\x01x"\x05\n\x03bar"\x03\n\x01y'  # noqa
+
+
+def test_polygon_encoding():
+    tile = Tile()
+    poly = Layer(tile, b'polygon')
+    feature = Polygon(poly)
+    feature.add_ring(5)
+    feature.set_point(0, 0)
+    feature.set_point(10, 0)
+    feature.set_point(10, 10)
+    feature.set_point(0, 10)
+    feature.close_ring()
+    feature.add_property(b'foo', b'bar')
+    feature.add_property(b'x', b'y')
+    feature.commit()
+    assert tile.serialize() == b'\x1a9x\x02\n\x07polygon(\x80 \x12\x15\x18\x03"\x0b\t\x00\x00\x1a\x14\x00\x00\x14\x13\x00\x0f\x12\x04\x00\x00\x01\x01\x1a\x03foo\x1a\x01x"\x05\n\x03bar"\x03\n\x01y'  # noqa
+
+    tile = Tile()
+    poly = Layer(tile, b'polygon')
+    feature = Polygon(poly)
+    feature.set_id(1)
+    feature.add_ring(5)
+    feature.set_point(0, 0)
+    feature.set_point(10, 0)
+    feature.set_point(10, 10)
+    feature.set_point(0, 10)
+    feature.close_ring()
+    feature.add_property(b'foo', b'bar')
+    feature.add_property(b'x', b'y')
+    feature.commit()
+    assert tile.serialize() == b'\x1a;x\x02\n\x07polygon(\x80 \x12\x17\x18\x03\x08\x01"\x0b\t\x00\x00\x1a\x14\x00\x00\x14\x13\x00\x0f\x12\x04\x00\x00\x01\x01\x1a\x03foo\x1a\x01x"\x05\n\x03bar"\x03\n\x01y'  # noqa
+
+    tile = Tile()
+    poly = Layer(tile, b'polygon')
+    feature = Polygon(poly)
+    feature.add_ring(5)
+    feature.set_point(0, 0)
+    feature.set_point(10, 0)
+    feature.set_point(10, 10)
+    feature.set_point(0, 10)
+    feature.set_point(0, 0)
+    feature.add_property(b'foo', b'bar')
+    feature.add_property(b'x', b'y')
+    feature.commit()
+    assert tile.serialize() == b'\x1a9x\x02\n\x07polygon(\x80 \x12\x15\x18\x03"\x0b\t\x00\x00\x1a\x14\x00\x00\x14\x13\x00\x0f\x12\x04\x00\x00\x01\x01\x1a\x03foo\x1a\x01x"\x05\n\x03bar"\x03\n\x01y'  # noqa

--- a/vtzero/cvtzero.pxd
+++ b/vtzero/cvtzero.pxd
@@ -96,6 +96,17 @@ cdef extern from 'vtzero/builder.hpp' namespace 'vtzero':
         void commit()
         void rollback()
 
+    cdef cppclass linestring_feature_builder:
+        linestring_feature_builder()
+        linestring_feature_builder(layer_builder layer)
+        void add_linestring(uint32_t count)
+        void set_point(const point p)
+        void set_point(const int32_t x, const int32_t y)
+        void add_property(char* key, char* value)
+        void set_id(const uint64_t id)
+        void commit()
+        void rollback()
+
     cdef cppclass tile_builder:
         tile_builder()
         layer_builder_impl* add_layer(layer& layer)

--- a/vtzero/cvtzero.pxd
+++ b/vtzero/cvtzero.pxd
@@ -75,10 +75,24 @@ cdef extern from 'vtzero/builder.hpp' namespace 'vtzero':
     cdef cppclass point_feature_builder:
         point_feature_builder()
         point_feature_builder(layer_builder layer)
+        void add_point(const int32_t x, const int32_t y)
         void add_points(uint32_t count)
         void set_point(const point p)
         void set_point(const int32_t x, const int32_t y)
-        void add_property(char* key, char* value)  # Fixme: use template args.
+        void add_property(char* key, char* value)
+        void set_id(const uint64_t id)
+        void commit()
+        void rollback()
+
+    cdef cppclass polygon_feature_builder:
+        polygon_feature_builder()
+        polygon_feature_builder(layer_builder layer)
+        void add_ring(uint32_t count)
+        void close_ring()
+        void set_point(const point p)
+        void set_point(const int32_t x, const int32_t y)
+        void add_property(char* key, char* value)
+        void set_id(const uint64_t id)
         void commit()
         void rollback()
 

--- a/vtzero/tile.pyx
+++ b/vtzero/tile.pyx
@@ -172,3 +172,29 @@ cdef class Polygon:
 
     def rollback(self):
         self.builder.rollback()
+
+
+cdef class Linestring:
+
+    cdef cvtzero.linestring_feature_builder* builder
+
+    def __cinit__(self, Layer layer):
+        self.builder = new cvtzero.linestring_feature_builder(layer.builder[0])
+
+    def add_linestring(self, count):
+        self.builder.add_linestring(count)
+
+    def set_point(self, x, y):
+        self.builder.set_point(x, y)
+
+    def add_property(self, char* key, char* value):
+        self.builder.add_property(key, value)
+
+    def set_id(self, int id):
+        self.builder.set_id(id)
+
+    def commit(self):
+        self.builder.commit()
+
+    def rollback(self):
+        self.builder.rollback()

--- a/vtzero/tile.pyx
+++ b/vtzero/tile.pyx
@@ -3,8 +3,6 @@ from libcpp.string cimport string
 from libc.stdint cimport uint32_t
 
 
-
-
 cdef class VectorTile:
 
     UNKNOWN = cvtzero.GeomType.UNKNOWN
@@ -98,28 +96,6 @@ cdef class VectorFeature:
     def geometry_type(self):
         return self.feature.geometry_type()
 
-#     @property
-#     def geometry(self):
-#         cdef VectorPoint handler = VectorPoint()
-#         cvtzero.decode_point_geometry(self.feature.geometry(), True, handler)
-#         return handler.data
-
-
-# cdef class VectorPoint:
-
-#     cdef cvtzero.point data
-
-#     cdef points_begin(self, uint32_t count):
-#         self.data.reserve(count)
-
-#     cdef points_point(self, cvtzero.point point):
-#         self.data.push_back(point)
-
-#     cdef points_end(self):
-#         pass
-
-
-
 
 cdef class Tile:
 
@@ -144,8 +120,11 @@ cdef class Point:
 
     cdef cvtzero.point_feature_builder* builder
 
-    def __cinit__(self, Layer layer, int id):
+    def __cinit__(self, Layer layer):
         self.builder = new cvtzero.point_feature_builder(layer.builder[0])
+
+    def add_point(self, x, y):
+        self.builder.add_point(x, y)
 
     def add_points(self, count):
         self.builder.add_points(count)
@@ -155,6 +134,38 @@ cdef class Point:
 
     def add_property(self, char* key, char* value):
         self.builder.add_property(key, value)
+
+    def set_id(self, int id):
+        self.builder.set_id(id)
+
+    def commit(self):
+        self.builder.commit()
+
+    def rollback(self):
+        self.builder.rollback()
+
+
+cdef class Polygon:
+
+    cdef cvtzero.polygon_feature_builder* builder
+
+    def __cinit__(self, Layer layer):
+        self.builder = new cvtzero.polygon_feature_builder(layer.builder[0])
+
+    def add_ring(self, count):
+        self.builder.add_ring(count)
+
+    def close_ring(self, ):
+        self.builder.close_ring()
+
+    def set_point(self, x, y):
+        self.builder.set_point(x, y)
+
+    def add_property(self, char* key, char* value):
+        self.builder.add_property(key, value)
+
+    def set_id(self, int id):
+        self.builder.set_id(id)
 
     def commit(self):
         self.builder.commit()

--- a/vtzero/tile.pyx
+++ b/vtzero/tile.pyx
@@ -1,3 +1,5 @@
+"""vtzero.tile module."""
+
 cimport cvtzero
 from libcpp.string cimport string
 from libc.stdint cimport uint32_t


### PR DESCRIPTION
👋 @yohanboniface 

So I've solved the compilation problem (using Cython ~= 0.28) coming from the `enum` [class](https://github.com/tilery/python-vtzero/blob/master/vtzero/cvtzero.pxd#L63-L68) but I'm starting this PR to update this lib which could be useful... at least for myself 😄 

What this PR does: 
- remove id argument from feature (**Breacking change**)
- add `set_id` method for features
- add Polygon feature builder 

```
tile = Tile()
mvt_layer = Layer(tile, b'polygons')
feature = Polygon(mvt_layer)
feature.add_ring(5)
feature.set_point(0, 0)
feature.set_point(1, 0)
feature.set_point(1, 1)
feature.set_point(0, 1)
feature.close_ring()
feature.commit()
data = tile.serialize()
```
- update tests

### To Do 
- [x] add linearstring
- [x] Update Readme 
- [x] Update setup.py
- [ ] ~fix the enum bug~
- [] ~update `add_property` to accept other data type (than string)~
