### PR TITLE
PEP 518 compliance - install Cython before building

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,3 @@
 [build-system]
+build-backend = "setuptools.build_meta"
 requires = ["Cython==0.28"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["Cython==0.28"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
+requires = ["setuptools>=40.8.0", "wheel", "Cython==0.28"]
 build-backend = "setuptools.build_meta"
-requires = ["Cython==0.28"]


### PR DESCRIPTION
This should allow vtzero to be specified in a requirements.txt, currently it will not install from a requirements.txt because Cython needs to be installed first.