### PR TITLE
use cython language_level=3 ;

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,8 +46,9 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install tox
+          python -m pip install tox setuptools cython>=0.29.23
           git submodule update --init
+          python setup.py build_ext --inplace
 
       - name: Set tag version
         id: tag

--- a/vtzero/cvtzero.pxd
+++ b/vtzero/cvtzero.pxd
@@ -1,3 +1,5 @@
+# cython: language_level=3
+
 from libc.stdint cimport uint32_t, uint64_t, int32_t
 from libcpp.string cimport string
 from libcpp cimport bool

--- a/vtzero/tile.pyx
+++ b/vtzero/tile.pyx
@@ -1,6 +1,8 @@
+# cython: language_level=3
+
 """vtzero.tile module."""
 
-cimport cvtzero
+from vtzero cimport cvtzero
 from libcpp.string cimport string
 from libc.stdint cimport uint32_t
 


### PR DESCRIPTION
previous `publish` gh actions were failing because of a warning emitted when compiling the library. 

This PR adds `language_level=3` on top of Cython files to resolve the warning.